### PR TITLE
Bug 876369 - B2G Emulator: Support switching modem radio technology

### DIFF
--- a/reference-ril/reference-ril.c
+++ b/reference-ril/reference-ril.c
@@ -3279,7 +3279,7 @@ static void onUnsolicited (const char *s, const char *sms_pdu)
             case 1: // current mode correctly parsed
             case 0: // preferred mode correctly parsed
                 mask = 1 << tech;
-                if (mask != MDM_GSM && mask != MDM_CDMA &&
+                if (mask != MDM_GSM && mask != MDM_CDMA && mask != MDM_EVDO &&
                      mask != MDM_WCDMA && mask != MDM_LTE) {
                     ALOGE("Unknown technology %d\n", tech);
                 } else {


### PR DESCRIPTION
Please see [bug 876369](https://bugzilla.mozilla.org/show_bug.cgi?id=876369).

Below is the detailed information for this pull request:
1. Cherry-pick patches from 'next/jb-mr1-release' for more CDMA support and upgrade to RILv7
2. Patches for status updating after radio status change.

*Note: I can pass all existed marionette tests with these patches in my local build.

Thanks
