### PR TITLE
Bug 891707 - B2G Emulator: update voice registration after switching radio technology

### DIFF
--- a/reference-ril/reference-ril.c
+++ b/reference-ril/reference-ril.c
@@ -1439,7 +1439,7 @@ static void requestRegistrationState(int request, void *data,
         // TODO: Query modem
         startfrom = 3;
         if(request == RIL_REQUEST_VOICE_REGISTRATION_STATE) {
-            asprintf(&responseStr[3], "8");     // EvDo revA
+            asprintf(&responseStr[3], "%d", type);  // Radio Technology
             asprintf(&responseStr[4], "1");     // BSID
             asprintf(&responseStr[5], "123");   // Latitude
             asprintf(&responseStr[6], "222");   // Longitude

--- a/reference-ril/reference-ril.c
+++ b/reference-ril/reference-ril.c
@@ -2754,6 +2754,8 @@ setRadioTechnology(ModemInfo *mdm, int newtech)
             if (tech > 0 ) {
                 RIL_onUnsolicitedResponse(RIL_UNSOL_VOICE_RADIO_TECH_CHANGED,
                                           &tech, sizeof(tech));
+                RIL_onUnsolicitedResponse (RIL_UNSOL_RESPONSE_VOICE_NETWORK_STATE_CHANGED,
+                                           NULL, 0);
             }
         }
     }


### PR DESCRIPTION
Please see [bug 891707](https://bugzilla.mozilla.org/show_bug.cgi?id=891707).
