### PR TITLE
Bug 970212 - B2G Emulator: Enhance GSM/UMTS Signal Strength on Emulator.

### DIFF
--- a/reference-ril/reference-ril.c
+++ b/reference-ril/reference-ril.c
@@ -936,19 +936,28 @@ error:
     RIL_onRequestComplete(t, RIL_E_GENERIC_FAILURE, NULL, 0);
 }
 
+static int handleSignalStrength(char *line, RIL_SignalStrength_v6 *response) {
+    int num = sizeof(RIL_SignalStrength_v6) / sizeof(int);
+    int *p = (int *)response;
+
+    while (num--) {
+        if (at_tok_nextint(&line, p++) < 0) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static void requestSignalStrength(void *data, size_t datalen, RIL_Token t)
 {
     ATResponse *p_response = NULL;
     int err;
     char *line;
-    int count =0;
-    int numofElements=sizeof(RIL_SignalStrength_v6)/sizeof(int);
-    int response[numofElements];
-
+    RIL_SignalStrength_v6 response;
+    
     err = at_send_command_singleline("AT+CSQ", "+CSQ:", &p_response);
 
     if (err < 0 || p_response->success == 0) {
-        RIL_onRequestComplete(t, RIL_E_GENERIC_FAILURE, NULL, 0);
         goto error;
     }
 
@@ -957,12 +966,10 @@ static void requestSignalStrength(void *data, size_t datalen, RIL_Token t)
     err = at_tok_start(&line);
     if (err < 0) goto error;
 
-    for (count =0; count < numofElements; count ++) {
-        err = at_tok_nextint(&line, &(response[count]));
-        if (err < 0) goto error;
-    }
+    err = handleSignalStrength(line, &response);
+    if (err < 0) goto error;
 
-    RIL_onRequestComplete(t, RIL_E_SUCCESS, response, sizeof(response));
+    RIL_onRequestComplete(t, RIL_E_SUCCESS, &response, sizeof(response));
 
     at_response_free(p_response);
     return;
@@ -3590,6 +3597,24 @@ static void onUnsolicited (const char *s, const char *sms_pdu)
         RIL_onUnsolicitedResponse(RIL_UNSOL_CDMA_PRL_CHANGED, &version, sizeof(version));
     } else if (strStartsWith(s, "+CFUN: 0")) {
         setRadioState(RADIO_STATE_OFF);
+    } else if (strStartsWith(s, "+CSQ:")) {
+        RIL_SignalStrength_v6 response;
+        line = p = strdup(s);
+        if (!line) {
+            ALOGE("+CSQ: Unable to allocate memory");
+            return;
+        }
+        if (at_tok_start(&p) < 0) {
+            ALOGE("invalid +CSQ response: %s", s);
+            free(line);
+            return;
+        }
+        if (handleSignalStrength(p, &response) < 0) {
+            free(line);
+            return;
+        }
+        free(line);
+        RIL_onUnsolicitedResponse(RIL_UNSOL_SIGNAL_STRENGTH, &response, sizeof(response));
     }
 }
 


### PR DESCRIPTION
Parse unsol. +CSQ: request, and mapping contain into RIL_SignalStrength_v6.
Send RIL_UNSOL_SIGNAL_STRENGTH to upper layer then.
