### PR TITLE
Bug 1067629 - Introduce a new unsolicited AT response (+CFUN: 1) to indicate radio is enabled. r=echen

### DIFF
--- a/reference-ril/reference-ril.c
+++ b/reference-ril/reference-ril.c
@@ -4248,8 +4248,35 @@ static void onUnsolicited (const char *s, const char *sms_pdu)
         }
         free(line);
         RIL_onUnsolicitedResponse(RIL_UNSOL_CDMA_PRL_CHANGED, &version, sizeof(version));
-    } else if (strStartsWith(s, "+CFUN: 0")) {
-        setRadioState(RADIO_STATE_OFF);
+    } else if (strStartsWith(s, "+CFUN:")) {
+        int state = -1;
+        line = p = strdup(s);
+        if (!line) {
+            RLOGE("+CFUN: Unable to allocate memory");
+            return;
+        }
+        if (at_tok_start(&p) < 0) {
+            RLOGE("invalid +CFUN response: %s", s);
+            free(line);
+            return;
+        }
+        if (at_tok_nextint(&p, &state) < 0) {
+            RLOGE("invalid +CFUN response: %s", s);
+            free(line);
+            return;
+        }
+        free(line);
+        switch (state) {
+            case 0:
+                setRadioState(RADIO_STATE_OFF);
+                break;
+            case 1:
+                setRadioState(RADIO_STATE_ON);
+                break;
+            default:
+                RLOGE("invalid +CFUN response: %s", s);
+                return;
+        }
     } else if (strStartsWith(s, "+CSQ:")) {
         RIL_SignalStrength_v6 response;
         line = p = strdup(s);


### PR DESCRIPTION
To automatically test [Bug 1067629](https://bugzilla.mozilla.org/show_bug.cgi?id=1067629) with an emulator, we need the an extra customized AT response (+CFUN: 1) to indicate the rado has been turned on.