### PR TITLE
Bug 1169585 - Check net2modem/net2pmask array boundary

### DIFF
--- a/reference-ril/reference-ril.c
+++ b/reference-ril/reference-ril.c
@@ -1139,8 +1139,10 @@ error:
  */
 static int networkModePossible(ModemInfo *mdm, int nm)
 {
-    if ((net2modem[nm] & mdm->supportedTechs) == net2modem[nm]) {
-       return 1;
+    if ((sizeof(net2pmask) / sizeof(int32_t)) > nm &&
+        (sizeof(net2modem) / sizeof(int)) > nm &&
+        (net2modem[nm] & mdm->supportedTechs) == net2modem[nm]) {
+        return 1;
     }
     return 0;
 }
@@ -1152,13 +1154,16 @@ static void requestSetPreferredNetworkType( int request, void *data,
     int value = *(int *)data;
     int current, old;
     int err;
-    int32_t preferred = net2pmask[value];
+    int32_t preferred;
 
-    ALOGD("requestSetPreferredNetworkType: current: %x. New: %x", PREFERRED_NETWORK(sMdmInfo), preferred);
     if (!networkModePossible(sMdmInfo, value)) {
         RIL_onRequestComplete(t, RIL_E_MODE_NOT_SUPPORTED, NULL, 0);
         return;
     }
+
+    preferred = net2pmask[value];
+    ALOGD("requestSetPreferredNetworkType: current: %x. New: %x", PREFERRED_NETWORK(sMdmInfo), preferred);
+
     if (query_ctec(sMdmInfo, &current, NULL) < 0) {
         RIL_onRequestComplete(t, RIL_E_GENERIC_FAILURE, NULL, 0);
         return;


### PR DESCRIPTION
hardware/ril doesn't support LTE/WCDMA as preferred mode. When setting
preferred mode to LTE/WCDMA, we get an unpredictable result due to
we access a memory address which is out of net2modem/net2pmask array boundary.

Please see [bug 1169585](https://bugzilla.mozilla.org/show_bug.cgi?id=1169585).
