### PR TITLE
Bug 1183578 - Reply RIL_E_REQUEST_NOT_SUPPORTED for the pin2 and puk2 operations

### DIFF
--- a/reference-ril/reference-ril.c
+++ b/reference-ril/reference-ril.c
@@ -3327,6 +3327,7 @@ onRequest (int request, void *data, size_t datalen, RIL_Token t)
         case RIL_REQUEST_ENTER_SIM_PUK2:
         case RIL_REQUEST_CHANGE_SIM_PIN2:
             // We don't support pin2 and puk2 in qemu currently.
+            RIL_onRequestComplete(t, RIL_E_REQUEST_NOT_SUPPORTED, NULL, 0);
             break;
 
         case RIL_REQUEST_GET_UNLOCK_RETRY_COUNT:


### PR DESCRIPTION
Please see [bug 1183578](https://bugzilla.mozilla.org/show_bug.cgi?id=1183578).

If we intent to reply `RIL_E_REQUEST_NOT_SUPPORTED` for the request that we don't support, we could just let it fall through to the default case.
