### PR TITLE
Bug 1231324 - Support REQUEST_CANCEL_USSD command

### DIFF
--- a/reference-ril/reference-ril.c
+++ b/reference-ril/reference-ril.c
@@ -3500,13 +3500,12 @@ onRequest (int request, void *data, size_t datalen, RIL_Token t)
 
         case RIL_REQUEST_CANCEL_USSD:
             p_response = NULL;
-            err = at_send_command_numeric("AT+CUSD=2", &p_response);
+            err = at_send_command("AT+CUSD=2", &p_response);
 
             if (err < 0 || p_response->success == 0) {
                 RIL_onRequestComplete(t, RIL_E_GENERIC_FAILURE, NULL, 0);
             } else {
-                RIL_onRequestComplete(t, RIL_E_SUCCESS,
-                    p_response->p_intermediates->line, sizeof(char *));
+                RIL_onRequestComplete(t, RIL_E_SUCCESS, NULL, 0);
             }
             at_response_free(p_response);
             break;


### PR DESCRIPTION
Use at_send_command as android_modem.c returns "OK" and not a numeric value.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla-b2g/platform_hardware_ril/76)

<!-- Reviewable:end -->
